### PR TITLE
Update navbar logo and footer

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -46,9 +46,8 @@ body {
 
 .nav-container {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 1.5rem 3rem;
+  padding: 1.5rem 2rem;
   max-width: 1400px;
   margin: 0 auto;
 }
@@ -98,6 +97,7 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 50px;
   padding: 0.8rem 2rem;
+  margin-left: auto;
   transition: all 0.3s ease;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
@@ -1591,8 +1591,9 @@ section.visible {
 
 .footer-content {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  gap: 1.5rem;
 }
 
 .footer-text {

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
   <nav class="navbar">
     <div class="nav-container">
       <div class="nav-logo">
-        <span class="nav-logo-text">JR</span>
+        <span class="nav-logo-text">{ }</span>
       </div>
       <div class="nav-menu">
         <a href="#hero" class="nav-link active">Home</a>
@@ -336,7 +336,7 @@
     <div class="container">
       <div class="footer-content">
         <div class="footer-text">
-          <p>&copy; 2024 Josh Robertson. All rights reserved.</p>
+          <p>&copy; 2025 Josh Robertson. All rights reserved.</p>
         </div>
         <div class="footer-links">
           <a href="https://github.com/joshrobertson8" target="_blank" class="social-link">


### PR DESCRIPTION
## Summary
- update navbar logo text to `{ }`
- push navigation menu to the far right
- center footer content and update copyright year

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871c21c1c6083258d97abf19002cc9e