### PR TITLE
Update tagline and navbar style

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -49,8 +49,7 @@ body {
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 2rem;
-  max-width: 1400px;
-  margin: 0 auto;
+  width: 100%;
 }
 
 .nav-logo {
@@ -285,6 +284,7 @@ body {
   gap: 0.5rem;
   margin-bottom: 3rem;
   position: relative;
+  transform: translateX(-4px);
 }
 
 .logo-j, .logo-r {
@@ -867,6 +867,7 @@ section.visible {
   
   .hero-logo-text {
     gap: 0.3rem;
+    transform: translateX(-4px);
   }
   
   .hero-logo::before {
@@ -1633,6 +1634,7 @@ section.visible {
 
   .hero-logo-text {
     flex-direction: row;
+    transform: translateX(-4px);
   }
 
   .logo-j, .logo-r {

--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
             
           </div>
           <div class="code-line">
-            <span class="punctuation">></span> <span class="comment">Engineering to solve problems, writing it for purpose.</span>
+            <span class="comment"><strong>Engineering to solve problems, writing it for purpose.</strong></span>
           </div>
               <div class="code-line">
                 <span class="cursor">|</span>


### PR DESCRIPTION
## Summary
- tweak navbar container so menu sits near page edge
- center hero logo text better on the home page
- bold tagline text and drop the leading symbol

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871c8a3b81083258981f407e839c348